### PR TITLE
sourceunstable Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 A video.js plugin for enhancing a player with behaviors related to changing media sources.
 
+## Why?
+
+Detecting when the media source of a player has changed or is about to change is an inexact operation because the resource selection algorithm is asynchronous.
+
+For the most part, Video.js users will be familiar with using the `Player#src()` method to change the source of the player. One might wonder why we don't simply trigger an event from that function to signal that the source is going to change.
+
+The problem with that is that `src()` is not the only way to change the source. The underlying `<video>` element has multiple methods of changing the source as well and we aim to support those here.
+
+This plugin provides events and other tools that aim to make that uncertainty a little less daunting.
+
 ## Installation
 
 ```sh
@@ -65,13 +75,19 @@ require(['video.js', 'videojs-per-source-behaviors'], function(videojs) {
 
 Once the plugin is invoked on a player - by calling `player.perSourceBehaviors()` - it begins firing a new event, gains two new methods, and replaces `perSourceBehaviors` with an object.
 
-### `"sourcechanged"` Event
+### `sourceunstable` Event
 
-The `"sourcechanged"` event will be fired once the call stack is cleared after the first of [a subset][subset-events] of standard [`HTMLMediaElement` events][standard-events] is encountered where the `currentSrc()` returned by the player has changed.
+The `sourceunstable` event will be fired when the plugin detects a condition that suggests the video player is in the process of changing sources, but that it's too early to know what the new source is or will be.
+
+This is not a guarantee that the source will even change, but it's close - and one of the goals of this project is to continually improve this detection.
+
+### `sourcechanged` Event
+
+The `sourcechanged` event will be fired once the call stack is cleared after the first of a subset of standard [`HTMLMediaElement` events][standard-events] is encountered where the `currentSrc()` returned by the player has changed from the previously cached value.
 
 #### Extra Event Data
 
-An object with the following properties is passed along with `"sourcechanged"` events as the second argument to any listeners:
+An object with the following properties is passed along with `sourcechanged` events as the second argument to any listeners:
 
 - `from`: The source URL _before_ the event.
 - `to`: The source URL _after_ the event (and currently).
@@ -106,7 +122,7 @@ This is useful in more complex use-cases where you might want to manipulate the 
 
 #### What happens when per-source behaviors are disabled?
 
-- The `"sourcechanged"` event will not be fired even if the source changes.
+- The `sourcechanged` event will not be fired even if the source changes.
 - Any `onPerSrc()`/`onePerSrc()` listeners will not be called.
 - Binding new `onPerSrc()`/`onePerSrc()` listeners will be prevented.
 
@@ -124,5 +140,4 @@ Apache-2.0. Copyright (c) Brightcove, Inc.
 
 
 [standard-events]: https://www.w3.org/TR/html5/embedded-content-0.html#mediaevents
-[subset-events]: https://github.com/brightcove/videojs-per-source-behaviors/blob/master/src/plugin.js#L13
 [videojs]: http://videojs.com/

--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
   <link href="/node_modules/video.js/dist/video-js.css" rel="stylesheet">
 </head>
 <body>
-  <video id="videojs-per-source-behaviors-player" class="video-js vjs-default-skin" controls>
-    <source src="//vjs.zencdn.net/v/oceans.mp4" type='video/mp4'>
-    <source src="//vjs.zencdn.net/v/oceans.webm" type='video/webm'>
-  </video>
+  <video id="videojs-per-source-behaviors-player" class="video-js" controls></video>
+  <p>
+    <button id="change-source">Change the Source</button>
+  </p>
   <ul>
     <li><a href="/test/">Run unit tests in browser.</a></li>
   </ul>
@@ -17,17 +17,79 @@
   <script src="/dist/videojs-per-source-behaviors.js"></script>
   <script>
     (function(window, videojs) {
+      console.log('to view the current state, call `console.table(playerEvents);`');
+
       var player = window.player = videojs('videojs-per-source-behaviors-player');
 
+      var sources = [
+        'https://vjs.zencdn.net/v/oceans.mp4',
+        'https://archive.org/download/ElephantsDream/ed_hd.mp4',
+        'https://archive.org/download/Sintel/sintel-2048-stereo_512kb.mp4'
+      ];
+
+      var currentSource = 0;
+
+      var networkStates = [
+        'NETWORK_EMPTY',
+        'NETWORK_IDLE',
+        'NETWORK_LOADING',
+        'NETWORK_NO_SOURCE'
+      ];
+
+      var readyStates = [
+        'HAVE_NOTHING',
+        'HAVE_METADATA',
+        'HAVE_CURRENT_DATA',
+        'HAVE_FUTURE_DATA',
+        'HAVE_ENOUGH_DATA'
+      ];
+
+      var playerEvents = window.playerEvents = [];
+
       player.on(videojs.getTech('Html5').Events, function(e) {
-        videojs.log(e.type, ' at ', Date.now());
+        videojs.log(e.type + ' at ' + Date.now());
+        playerEvents.push({
+          networkState: networkStates[player.networkState()],
+          readyState: readyStates[player.readyState()],
+          time: Date.now(),
+          type: e.type
+        });
       });
 
-      player.on('sourcechanged', function(e, data) {
-        videojs.log('SOURCE CHANGED!', e, data);
+      player.on(['sourceunstable', 'sourcechanged'], function(e, data) {
+        videojs.log(e.type.toUpperCase() + ' at ' + Date.now());
+        playerEvents.push({
+          data: data,
+          networkState: networkStates[player.networkState()],
+          readyState: readyStates[player.readyState()],
+          time: Date.now(),
+          type: e.type
+        });
       });
 
       player.perSourceBehaviors();
+
+      player.src(sources[currentSource]);
+
+      var changeSourceBtn = document.getElementById('change-source');
+
+      changeSourceBtn.addEventListener('click', function(e) {
+        var wasPlaying = !player.paused();
+
+        e.preventDefault();
+        currentSource++;
+
+        if (currentSource === sources.length) {
+          currentSource = 0;
+        }
+
+        videojs.log('about to change the source');
+        player.src(sources[currentSource]);
+
+        if (wasPlaying) {
+          player.play();
+        }
+      });
     }(window, window.videojs));
   </script>
 </body>

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -12,13 +12,20 @@ const Html5 = videojs.getTech('Html5');
  */
 const CHANGE_DETECT_EVENTS = [
   'abort',
-  'canplay',
   'emptied',
-  'loadeddata',
-  'loadedmetadata',
   'loadstart',
-  'play',
-  'playing'
+  'play'
+];
+
+/**
+ * These events will indicate that the source is "unstable" (i.e. it might be
+ * about to change).
+ *
+ * @type {Array}
+ */
+const UNSTABLE_EVENTS = [
+  'abort',
+  'emptied'
 ];
 
 /**
@@ -156,6 +163,7 @@ const perSourceBehaviors = function() {
   let cachedSrc;
   let disabled = false;
   let srcChangeTimer;
+  let srcStable = true;
 
   this.perSourceBehaviors = {
 
@@ -199,6 +207,16 @@ const perSourceBehaviors = function() {
       return !disabled;
     },
 
+    /**
+     * Whether or not the source is "stable". This will return `true` if the
+     * plugin feels that we may be about to change sources.
+     *
+     * @return {Boolean}
+     */
+    isSrcStable() {
+      return srcStable;
+    },
+
     VERSION: '__VERSION__'
   };
 
@@ -208,31 +226,44 @@ const perSourceBehaviors = function() {
 
   this.on(CHANGE_DETECT_EVENTS, (e) => {
 
+    // Bail-out conditions.
     if (
       this.perSourceBehaviors.disabled() ||
       srcChangeTimer ||
-      !this.currentSrc() ||
       isInAdPlayback(this)
     ) {
       return;
+    }
+
+    // If we did not previously detect that we were in an unstable state and
+    // this was an event that qualifies as unstable, do that now. In the future,
+    // we may want to restrict the conditions under which this is triggered by
+    // checking networkState and/or readyState for reasonable values such as
+    // NETWORK_NO_SOURCE and HAVE_NOTHING.
+    if (
+      srcStable &&
+      UNSTABLE_EVENTS.indexOf(e.type) > -1
+    ) {
+      srcStable = false;
+      this.trigger('sourceunstable');
     }
 
     // Track any and all interim events from this one until the next tick
     // when we evaluate the timer.
     const interimEvents = [];
 
-    const addInterimEvent = (f) => {
+    const addInterimEvent = (f) =>
       interimEvents.push({time: Date.now(), event: f});
-    };
 
     addInterimEvent(e);
     this.on(Html5.Events, addInterimEvent);
 
-    srcChangeTimer = window.setTimeout(() => {
+    srcChangeTimer = this.setTimeout(() => {
       let currentSrc = this.currentSrc();
 
-      this.off(Html5.Events, addInterimEvent);
+      srcStable = true;
       srcChangeTimer = null;
+      this.off(Html5.Events, addInterimEvent);
 
       if (currentSrc && currentSrc !== cachedSrc) {
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -4,7 +4,7 @@ const Html5 = videojs.getTech('Html5');
 
 /**
  * For the most part, these are the events that occur early in the lifecycle
- * of a player, but there is considerable variability across browsers and
+ * of a source, but there is considerable variability across browsers and
  * devices (not to mention properties like autoplay and preload). As such, we
  * listen to a bunch of events for source changes.
  *
@@ -22,17 +22,26 @@ const CHANGE_DETECT_EVENTS = [
 ];
 
 /**
+ * These are the ad loading and playback states we care about.
+ *
+ * @type {Array}
+ */
+const AD_STATES = [
+  'ad-playback',
+  'ads-ready',
+  'postroll?',
+  'preroll?'
+];
+
+/**
  * Whether or not the player is in an ad state. Ideally, this function would
  * not need to exist, but hooks provided by contrib-ads are not sufficient to
  * cover all conditions at this time.
  *
- * Additionally, it'd be preferable to not have to read from the DOM and have
- * external code simply disable/enable "sourcechanged" detection when entering
- * or leaving an ad state.
- *
  * @return {Boolean}
  */
-const isInAdPlayback = (p) => p.hasClass('vjs-ad-loading') || p.hasClass('vjs-ad-playing');
+const isInAdPlayback = (p) =>
+  !!p.ads && typeof p.ads === 'object' && AD_STATES.indexOf(p.ads.state) > -1;
 
 /**
  * Creates an event binder function of a given type.

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -67,6 +67,28 @@ QUnit.test('disable(), disabled(), enable()', function(assert) {
   assert.notOk(psb.disabled(), 'per-source behaviors can be enabled');
 });
 
+QUnit.test('"sourceunstable" event', function(assert) {
+  const spy = sinon.spy();
+
+  this.player.on('sourceunstable', spy);
+  this.player.trigger('abort');
+
+  // For each assertion, tick 10ms to be sure multiple timeouts do not happen!
+  this.clock.tick(10);
+  assert.strictEqual(spy.callCount, 1, '"sourceunstable" events can be triggered by "abort"');
+
+  this.player.trigger('emptied');
+  this.clock.tick(10);
+  assert.strictEqual(spy.callCount, 2, '"sourceunstable" events can be triggered by "emptied"');
+
+  this.player.trigger('abort');
+  this.player.trigger('emptied');
+  this.player.trigger('abort');
+  this.player.trigger('emptied');
+  this.clock.tick(10);
+  assert.strictEqual(spy.callCount, 3, '"sourceunstable" events will only trigger once during a stack');
+});
+
 QUnit.test('"sourcechanged" event', function(assert) {
   const spy = sinon.spy();
 
@@ -120,9 +142,9 @@ QUnit.test('"sourcechanged" event', function(assert) {
   `);
 
   this.player.currentSrc = () => 'x-2.mp4';
+  this.player.trigger('loadstart');
   this.player.trigger('loadedmetadata');
   this.player.trigger('loadeddata');
-  this.player.trigger('loadstart');
   this.clock.tick(10);
 
   assert.strictEqual(spy.callCount, 2, 'with a new source, got a "sourcechanged" event');
@@ -132,13 +154,13 @@ QUnit.test('"sourcechanged" event', function(assert) {
     to: 'x-2.mp4',
     interimEvents: [{
       time: 31,
+      type: 'loadstart'
+    }, {
+      time: 31,
       type: 'loadedmetadata'
     }, {
       time: 31,
       type: 'loadeddata'
-    }, {
-      time: 31,
-      type: 'loadstart'
     }]
   });
 


### PR DESCRIPTION
This adds a `sourceunstable` event that signals to the user of this plugin that it looks like the source is in the process of changing.