### PR TITLE
Remove per-src listeners when we know the source changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Put another way, the object follows the following schema:
 
 The `onPerSrc()` method has the same behavior as `on()` with the crucial exception that it will unbind itself if the listener is ever called with a different source than when it was bound.
 
+Additionally, these listeners will be removed immediately before the plugin triggers a `sourcechanged` event. This is done because one of the core use-cases is adding new per-source listeners on the `sourcechanged` event and there is a chance they can double-up otherwise.
+
 ### `player.onePerSrc()`
 
 The `onePerSrc()` method has the same behavior as `onPerSrc()` except that it can only be called _once_.

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -225,6 +225,11 @@ const perSourceBehaviors = function() {
    */
   this.onePerSrc = createPerSrcBinder(true);
 
+  // Clear out perSrcListeners cache on player dispose.
+  this.on('dispose', () => {
+    perSrcListeners.length = 0;
+  });
+
   this.on(CHANGE_DETECT_EVENTS, (e) => {
 
     // Bail-out conditions.

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -142,12 +142,12 @@ const perSourceBehaviors = function() {
      *
      * @return {Boolean}
      */
-    disable() {
-      window.clearTimeout(srcChangeTimer);
+    disable: videojs.bind(this, function disable() {
+      this.clearTimeout(srcChangeTimer);
       srcChangeTimer = null;
       disabled = true;
       return disabled;
-    },
+    }),
 
     /**
      * Whether per-source behaviors are disabled on this player.

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -44,129 +44,96 @@ const AD_STATES = [
 ];
 
 /**
- * Whether or not the player is in an ad state. Ideally, this function would
- * not need to exist, but hooks provided by contrib-ads are not sufficient to
- * cover all conditions at this time.
- *
- * @return {Boolean}
- */
-const isInAdPlayback = (p) =>
-  !!p.ads && typeof p.ads === 'object' && AD_STATES.indexOf(p.ads.state) > -1;
-
-/**
- * Creates an event binder function of a given type.
- *
- * @param  {Boolean} isOne
- *         Rather than delegating to the player's `one()` method, we want to
- *         retain full control over when the listener is unbound (particularly
- *         due to the ability for per-source behaviors to be toggled on and
- *         off at will).
- *
- * @return {Function}
- */
-const createPerSrcBinder = (isOne) => {
-  return function(first, second) {
-
-    // Do not bind new listeners when per-source behaviors are disabled.
-    if (this.perSourceBehaviors.disabled()) {
-      return;
-    }
-
-    const isTargetPlayer = arguments.length === 2;
-    const originalSrc = this.currentSrc();
-
-    // This array is the set of arguments to use for `on()` and `off()` methods
-    // of the player.
-    const args = [first];
-
-    // Make sure we bind here so that a GUID is set on the original listener
-    // and that it is bound to the proper context.
-    const originalListener = videojs.bind(
-      isTargetPlayer ? this : first,
-      arguments[arguments.length - 1]
-    );
-
-    // The wrapped listener `subargs` are the arguments passed to the original
-    // listener (i.e. the Event object and an additional data hash).
-    const wrappedListener = (...subargs) => {
-      const changed = this.currentSrc() !== originalSrc;
-
-      // Do not evaluate listeners if per-source behaviors are disabled.
-      if (this.perSourceBehaviors.disabled()) {
-        return;
-      }
-
-      if (changed || isOne) {
-        this.off(...args);
-      }
-
-      if (!changed) {
-        originalListener(...subargs);
-      }
-    };
-
-    // Make sure the wrapped listener and the original listener share a GUID,
-    // so that video.js properly removes event bindings when `off()` is passed
-    // the original listener!
-    wrappedListener.guid = originalListener.guid;
-
-    // If we are targeting a different object from the player, we need to include
-    // the second argument.
-    if (!isTargetPlayer) {
-      args.push(second);
-    }
-
-    args.push(wrappedListener);
-
-    return this.on(...args);
-  };
-};
-
-/**
- * Bind an event listener on a per-source basis.
- *
- * @function onPerSrc
- * @param  {String|Array|Component|Element} first
- *         The event type(s) or target Component or Element.
- *
- * @param  {Function|String|Array} second
- *         The event listener or event type(s) (when `first` is target).
- *
- * @param  {Function} third
- *         The event listener (when `second` is event type(s)).
- *
- * @return {Player}
- */
-const onPerSrc = createPerSrcBinder();
-
-/**
- * Bind an event listener on a per-source basis. This listener can only
- * be called once.
- *
- * @function onePerSrc
- * @param  {String|Array|Component|Element} first
- *         The event type(s) or target Component or Element.
- *
- * @param  {Function|String|Array} second
- *         The event listener or event type(s) (when `first` is target).
- *
- * @param  {Function} third
- *         The event listener (when `second` is event type(s)).
- *
- * @return {Player}
- */
-const onePerSrc = createPerSrcBinder(true);
-
-/**
  * Applies per-source behaviors to a video.js Player object.
  *
  * @function perSourceBehaviors
  */
 const perSourceBehaviors = function() {
+  const perSrcListeners = [];
   let cachedSrc;
   let disabled = false;
   let srcChangeTimer;
   let srcStable = true;
+
+  /**
+   * Whether or not the player is in an ad state. Ideally, this function would
+   * not need to exist, but hooks provided by contrib-ads are not sufficient to
+   * cover all conditions at this time.
+   *
+   * @return {Boolean}
+   */
+  const isInAdPlayback = () =>
+    !!this.ads && typeof this.ads === 'object' && AD_STATES.indexOf(this.ads.state) > -1;
+
+  /**
+   * Creates an event binder function of a given type.
+   *
+   * @param  {Boolean} isOne
+   *         Rather than delegating to the player's `one()` method, we want to
+   *         retain full control over when the listener is unbound (particularly
+   *         due to the ability for per-source behaviors to be toggled on and
+   *         off at will).
+   *
+   * @return {Function}
+   */
+  const createPerSrcBinder = (isOne) => {
+    return function(first, second) {
+
+      // Do not bind new listeners when per-source behaviors are disabled.
+      if (this.perSourceBehaviors.disabled()) {
+        return;
+      }
+
+      const isTargetPlayer = arguments.length === 2;
+      const originalSrc = this.currentSrc();
+
+      // This array is the set of arguments to use for `on()` and `off()` methods
+      // of the player.
+      const args = [first];
+
+      // Make sure we bind here so that a GUID is set on the original listener
+      // and that it is bound to the proper context.
+      const originalListener = videojs.bind(
+        isTargetPlayer ? this : first,
+        arguments[arguments.length - 1]
+      );
+
+      // The wrapped listener `subargs` are the arguments passed to the original
+      // listener (i.e. the Event object and an additional data hash).
+      const wrappedListener = (...subargs) => {
+        const changed = this.currentSrc() !== originalSrc;
+
+        // Do not evaluate listeners if per-source behaviors are disabled.
+        if (this.perSourceBehaviors.disabled()) {
+          return;
+        }
+
+        if (changed || isOne) {
+          this.off(...args);
+        }
+
+        if (!changed) {
+          originalListener(...subargs);
+        }
+      };
+
+      // Make sure the wrapped listener and the original listener share a GUID,
+      // so that video.js properly removes event bindings when `off()` is passed
+      // the original listener!
+      wrappedListener.guid = originalListener.guid;
+
+      // If we are targeting a different object from the player, we need to include
+      // the second argument.
+      if (!isTargetPlayer) {
+        args.push(second);
+      }
+
+      args.push(wrappedListener);
+      perSrcListeners.push(args);
+
+      return this.on(...args);
+    };
+  };
 
   this.perSourceBehaviors = {
 
@@ -223,9 +190,40 @@ const perSourceBehaviors = function() {
     VERSION: '__VERSION__'
   };
 
-  // Add the per-source event binding methods to this player.
-  this.onPerSrc = onPerSrc;
-  this.onePerSrc = onePerSrc;
+  /**
+   * Bind an event listener on a per-source basis.
+   *
+   * @function onPerSrc
+   * @param  {String|Array|Component|Element} first
+   *         The event type(s) or target Component or Element.
+   *
+   * @param  {Function|String|Array} second
+   *         The event listener or event type(s) (when `first` is target).
+   *
+   * @param  {Function} third
+   *         The event listener (when `second` is event type(s)).
+   *
+   * @return {Player}
+   */
+  this.onPerSrc = createPerSrcBinder();
+
+  /**
+   * Bind an event listener on a per-source basis. This listener can only
+   * be called once.
+   *
+   * @function onePerSrc
+   * @param  {String|Array|Component|Element} first
+   *         The event type(s) or target Component or Element.
+   *
+   * @param  {Function|String|Array} second
+   *         The event listener or event type(s) (when `first` is target).
+   *
+   * @param  {Function} third
+   *         The event listener (when `second` is event type(s)).
+   *
+   * @return {Player}
+   */
+  this.onePerSrc = createPerSrcBinder(true);
 
   this.on(CHANGE_DETECT_EVENTS, (e) => {
 
@@ -269,6 +267,11 @@ const perSourceBehaviors = function() {
       this.off(Html5.Events, addInterimEvent);
 
       if (currentSrc && currentSrc !== cachedSrc) {
+
+        // Remove per-source listeners explicitly when we know the source has
+        // changed before we trigger the "sourcechanged" listener.
+        perSrcListeners.forEach(args => this.off(...args));
+        perSrcListeners.length = 0;
 
         this.trigger('sourcechanged', {
           interimEvents,

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -408,3 +408,21 @@ QUnit.test('onePerSrc() event binding', function(assert) {
     when per-source behaviors are re-enabled, listeners are triggered
   `);
 });
+
+QUnit.test('"sourcechanged" removes per-source listeners', function(assert) {
+  const spy = sinon.spy();
+
+  this.player.currentSrc = () => 'x-1.mp4';
+  this.player.onPerSrc('foo', spy);
+  this.player.onePerSrc('foo', spy);
+
+  // Cause a "sourcechanged" event to trigger. This won't work by simply
+  // triggering the event. It needs to happen before the event.
+  this.player.currentSrc = () => 'x-2.mp4';
+  this.player.trigger('loadstart');
+  this.clock.tick(10);
+
+  this.player.trigger('foo');
+
+  assert.strictEqual(spy.callCount, 0, 'per source listeners were not called');
+});


### PR DESCRIPTION
This is a scenario that oddly seems to have caused a race condition in our player between per-source events being bound.

Specifically, it's a side-effect of a function with a consistent `guid` being re-bound to a per-source event. This is probably better as an example:

```js
const player = videojs('foo');

function onPlay() {}

player.on('sourcechanged', () => {
  player.onPerSrc('play', onPlay);
});
```

Given the above example, imagine the following scenario:

- Video source `"foo"` is loaded in the player, we get a `sourcechanged` event probably triggered by the `loadstart`.
- The `onPlay` listener is registered to the `play` event for `"foo"`.
- The user hits play, ultimately calling `onPlay` because the source has not changed since it was bound.
- Video source `"bar"` is loaded into the player, we get a `sourcechanged` event probably triggered by the `loadstart`.
- The `onPlay` listener is registered to the `play` event for `"bar"`, but because the `"foo"` listener shares the same `guid` (by virtue of the `onPlay` function being a single object), a new listener is _not_ created. Instead, we still have the `onPlay` bound to the `"foo"` source!
- The user hits play, ultimately calling `onPlay`, which unbinds itself because it thinks the source has changed out from under it!

The solution to this problem is to track per-source listeners and remove them _before_ we trigger the `sourcechanged` event.