### PR TITLE
fix: Add `ads-ready?` as a known ad state.

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -38,6 +38,7 @@ const UNSTABLE_EVENTS = [
  */
 const AD_STATES = [
   'ad-playback',
+  'ads-ready?',
   'postroll?',
   'preroll?'
 ];


### PR DESCRIPTION
This restores `ads-ready?` as a known ad state because it does indicate that contrib-ads has control.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
