### PR TITLE
chore: skip vjsverify es check

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "watch": "npm-run-all -p watch:*",
     "watch:js": "npm run build:js -- -w",
     "posttest": "shx cat test/dist/coverage/text.txt",
-    "prepublishOnly": "npm run build && vjsverify"
+    "prepublishOnly": "npm run build && vjsverify --skip-es-check"
   },
   "keywords": [
     "videojs",


### PR DESCRIPTION
## Description
Since the build output now includes ES6, we need to have `vjsverify` disregard it


